### PR TITLE
Implement vote mixing and expand SBB

### DIFF
--- a/src/election.py
+++ b/src/election.py
@@ -12,7 +12,7 @@ class Election:
         self,
         num_voters: int,
         M: int = 5,
-        twoM: int = 24,
+        twoM: int = 2,
         num_tablets: int = 3,
         num_proof_srv_rows: int = 3,
     ):

--- a/src/election.py
+++ b/src/election.py
@@ -56,6 +56,7 @@ class Election:
 
         # Step 5
         # End the election and mix votes.
+        print('Mixing votes...')
         self.proof_server.mix_votes()
 
         # Step 6

--- a/src/election.py
+++ b/src/election.py
@@ -10,9 +10,9 @@ from src import proof_server
 class Election:
     def __init__(
         self,
-        M: int = 3,
-        twoM: int = 2,
-        num_voters: int = 3,
+        num_voters: int,
+        M: int = 5,
+        twoM: int = 24,
         num_tablets: int = 3,
         num_proof_srv_rows: int = 3,
     ):
@@ -24,7 +24,7 @@ class Election:
         self.twoM = twoM
         self.sbb = sbb.SBB()
         self.proof_server = proof_server.ProofServer(
-            twoM=self.twoM, rows=num_proof_srv_rows, sbb=self.sbb,
+            M=self.M, twoM=self.twoM, rows=num_proof_srv_rows, sbb=self.sbb,
         )
         self.voters = [voter.Voter(voter_id=i, M=self.M) for i in range(num_voters)]
         self.tablets = [
@@ -40,10 +40,10 @@ class Election:
 
         self.sbb.post_ballots_and_commitments()
 
-        # End the election and mix votes
+        # End the election and mix votes.
         self.proof_server.mix_votes()
 
-        # Verify election results for each voter
+        # Verify election results for each voter.
         for v in self.voters:
             if not v.verify(self.sbb):
                 raise Exception('Voter ballot failed validation')

--- a/src/election.py
+++ b/src/election.py
@@ -1,10 +1,11 @@
 import random
-from typing import Optional
+from typing import Optional, Set
 
 from src import sbb
 from src import tablet
 from src import voter
 from src import proof_server
+from src import verifier
 
 
 class Election:
@@ -26,6 +27,7 @@ class Election:
         self.proof_server = proof_server.ProofServer(
             M=self.M, twoM=self.twoM, rows=num_proof_srv_rows, sbb=self.sbb,
         )
+        self.verifier = verifier.Verifier(sbb=self.sbb)
         self.voters = [voter.Voter(voter_id=i, M=self.M) for i in range(num_voters)]
         self.tablets = [
             tablet.Tablet(srv=self.proof_server, M=self.M, sbb=self.sbb)
@@ -34,21 +36,49 @@ class Election:
 
     def run(self):
         print('Running election...')
+
+        # Step 2
         for v in self.voters:
             t = self._get_tablet()
             v.do_vote(t)
 
+        # Step 3
         self.sbb.post_ballots_and_commitments()
 
+        # Step 4
+        # Verify election results for each voter.
+        sbb_contents = self.sbb.get_sbb_contents()
+        for v in self.voters:
+            if not v.verify(sbb_contents):
+                raise Exception('Voter ballot failed validation')
+            else:
+                print(f'Voter ID: {v.voter_id}, verified posted ballot hash: {v.ballot_hash}')
+
+        # Step 5
         # End the election and mix votes.
         self.proof_server.mix_votes()
 
-        # Verify election results for each voter.
-        for v in self.voters:
-            if not v.verify(self.sbb):
-                raise Exception('Voter ballot failed validation')
-            else:
-                print(f'Verified ballot for voter: {v.voter_id}')
+        # Step 6
+        # Create a random challenge specifying which `m` lists to use for proving
+        # consistency and (implicitly) which `m` votes to use for posting the
+        # election outcome.
+        all_two_m = set(range(self.twoM))
+        proof_lists: Set[int] = set(random.sample(all_two_m, self.twoM // 2))
+        outcome_lists: Set[int] = all_two_m - proof_lists
+        assert len(proof_lists) == len(outcome_lists) == self.twoM // 2
+
+        # Step 7
+        # Tell PS which lists to un-shuffle, partially decrypt, and post to the SBB.
+        self.proof_server.publish_vote_consistency_proof(proof_lists)
+        # A unrelated verifier server should be able to read the SBB and verify the
+        # proof that the partially decrypted votes are eqivalent to the SBB published
+        # cast votes from Step 3.
+        if not self.verifier.verify_ballot_consistency():
+            raise Exception('Could not verifier consistency of SBB posted ballots')
+
+        # Step 8
+        # Tell PS which (still shuffled) lists to fully decrypt and post to the SBB.
+        self.proof_server.publish_election_outcome(outcome_lists)
 
         # Election complete, cleanup steps.
         self.sbb.close()

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def parse_cmd_line(args):
         '-v', '--voters',
         action='store',
         dest='num_voters',
-        default=None,
+        default=3,
         type=int,
         help='number of voters to use, set randomly if not specified',
     )
@@ -31,6 +31,5 @@ if __name__ == '__main__':
     parsed = parse_cmd_line(sys.argv[1:])
     if parsed.interactive:
         print('Interactive mode not implemented yet')
-        pass
     else:
-        election.Election().run()
+        election.Election(num_voters=parsed.num_voters).run()

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def parse_cmd_line(args):
         '-v', '--voters',
         action='store',
         dest='num_voters',
-        default=3,
+        default=5,
         type=int,
         help='number of voters to use, set randomly if not specified',
     )

--- a/src/proof_server.py
+++ b/src/proof_server.py
@@ -238,7 +238,6 @@ class ProofServer:
         """
         self._validate_stored_votes()
 
-        print('Mixing votes...')
         for _ in range(self._twoM):
             self._mix_round()
 

--- a/src/proof_server.py
+++ b/src/proof_server.py
@@ -246,6 +246,8 @@ class ProofServer:
         # Validation of PS state that we need to reconstruct original ballot
         # order and to open `m` commitments later.
         assert len(self._permutation_arrays) == self._twoM
-        assert len(self._permutation_arrays[0]) == self._num_votes
+        assert len(self._permutation_arrays[0]) == self._rows
+        assert len(self._permutation_arrays[0][0]) == self._num_votes
         assert len(self._commitment_arrays) == self._twoM
-        assert len(self._commitment_arrays[0]) == self._num_votes
+        assert len(self._commitment_arrays[0]) == self._rows
+        assert len(self._commitment_arrays[0][0]) == self._num_votes

--- a/src/proof_server.py
+++ b/src/proof_server.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 from src import sv_vote
 from src import sbb
@@ -101,9 +101,15 @@ class ProofServer:
             raise Exception('Cannot handle vote without valid proof_server_row')
         self._incoming_vote_rows[sv_vote.proof_server_row].append(sv_vote)
 
-    def publish_vote_consistency_proof(self) -> None:
+    def publish_vote_consistency_proof(self, proof_lists: Set[int]) -> None:
         """
         Step #7 from Section I.
+        """
+        pass
+
+    def publish_election_outcome(self, outcome_lists: Set[int]) -> None:
+        """
+        Step #8 from Section I.
         """
         pass
 

--- a/src/proof_server.py
+++ b/src/proof_server.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+import random
+from typing import Dict, List, Tuple
 
 from src import sv_vote
 from src import sbb
@@ -17,7 +18,8 @@ class ProofServer:
     The function of the PS is to obfuscate and shuffle split-value-representations of
     ballots before posting to the SBB.
     """
-    def __init__(self, twoM: int, rows: int, sbb: sbb.SBB):
+    def __init__(self, M: int, twoM: int, rows: int, sbb: sbb.SBB):
+        self._M = M
         self._twoM = twoM
         self._sbb = sbb
         self._generate_key_pair()
@@ -86,11 +88,111 @@ class ProofServer:
     #
     # Proof server mixing implementation
     #
-    def _publish_proof(self):
+    def _publish_proof(self) -> None:
         pass
 
-    def mix_votes(self):
-        pass
+    def _validate_stored_votes(self) -> None:
+        """
+        Check that stored vote counts are consistent.
+        """
+        assert len(self._incoming_vote_rows) == self._rows
+        num_votes = {len(votes) for votes in self._incoming_vote_rows}
+        assert len(num_votes) == 1, 'All rows should have equal number of votes'
+        self._num_votes = num_votes.pop()
 
+    def _mix_round(self, iteration: int) -> None:
+        """
+        Run one round of randomized vote mixing.
 
+        Follows heading names used in Section VII. When operations are repeated
+        across each row, that row is responsible for just one component of the
+        SVR for the original ballot.
 
+        In the standard 3x3 PS topology this means:
+            row 0 -> x
+            row 1 -> y
+            row 2 -> z
+        """
+        # Each row retains a list of length _num_votes components of the ballot.
+        # Originally this list will correspond to the true order votes were made,
+        # after each stage of obfuscation+shuffling the list represents the current
+        # state of the row.
+        row_values: List[List[int]] = []
+
+        # Decryption - each server in the first column must decrypt the encrypted
+        # SVR component for all votes given to it, and confirm it matches the provided
+        # commitments. This ensures man-in-the-middle attacks are avoided.
+        for row in range(self._rows):
+            # One int per vote, at the end this is e.g. (x_1, ..., x_n).
+            vote_components: List[int] = []
+            votes = self._incoming_vote_rows[row]
+
+            for vote in votes:
+                decoder = self._tablet_decoders[vote.tablet_id]
+                plaintext_com: sv_vote.PlaintextCom = vote.enc.decode(decoder)
+                if (util.get_COM(plaintext_com.k1, plaintext_com.u) != vote.com_u or
+                    util.get_COM(plaintext_com.k2, plaintext_com.v) != vote.com_v):
+                    raise Exception('Commitment validation failed')
+
+                component_value = util.val(
+                    util.bytes_to_bigint(plaintext_com.u),
+                    util.bytes_to_bigint(plaintext_com.v),
+                    self._M,
+                )
+                vote_components.append(component_value)
+
+            assert len(vote_components) == self._num_votes
+            row_values.append(vote_components)
+
+        # Obfuscation and shuffling - done once per column.
+        for col in range(self._rows):
+            # Row 0 generates both obfuscation tuples (explained below) and a
+            # random permutation for shuffling, these lists are shared with the
+            # other rows. Normally this would be done with secure encrypted
+            # communication between the servers.
+            pi = list(range(self._num_votes))
+            random.shuffle(pi)
+
+            # An obfuscation is a tuple (p, q, r) where (p + q + r) mod M = 0,
+            # for each vote. And shares these with the other rows. These are
+            # used to obfuscate the vote components by computing, e.g.
+            # x' = (p + x) mod M. Note the new value of (x', y', z') is
+            # still equal to the original vote.
+            obfuscation_tuples: List[Tuple[int]] = [
+                util.get_SV_multiple(0, self._rows, self._M)
+                for _ in range(self._num_votes)
+            ]
+
+            # Create one list for each component (p, q, r) so they can be shared
+            # with the appropriate row.
+            obfuscation_lists = list(zip(*obfuscation_tuples))
+
+            for row in range(self._rows):
+                # Obfuscate
+                obfuscation_list = obfuscation_lists[row]
+                obfuscated_components = [
+                    util.val(u, p, self._M)
+                    for (u, p) in zip(obfuscation_list, row_values[row])
+                ]
+                # Shuffle - all servers in this column use the same shuffle permutation.
+                # This reassignment takes the place of secure server transfer, instead
+                # the latest component values states are kept in this list.
+                row_values[row][:] = [obfuscated_components[i] for i in pi]
+
+        # Post lists of votes - last column creates and posts SVR commitments for
+        # each value in the array of ballot components it contains.
+        for row in range(self._rows):
+            pass
+
+    def mix_votes(self) -> None:
+        """
+        Mix votes according to Section VII.
+
+        Implements 2m rounds of randomized vote obfuscation and shuffling across
+        all PS rows and columns. Each of the 2m rounds produces 1 of the eventually
+        2m lists posted to the SBB.
+        """
+        self._validate_stored_votes()
+
+        for iteration in range(self._twoM):
+            self._mix_round(iteration)

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -3,6 +3,8 @@ import json
 # Define SBB headings used to later parse the SBB during proof.
 BALLOT_RECEIPTS = 'ballot_receipts'
 COMMITMENTS = 'commitments'
+VOTE_LIST = 'vote_list'
+END_SECTION = 'end_section'
 
 class SBB:
     """
@@ -41,7 +43,15 @@ class SBB:
         self._db.write(BALLOT_RECEIPTS + '\n')
         for receipt in self._ballot_receipts:
             self._db.write(receipt + '\n')
+        self._db.write(END_SECTION + '\n')
 
         self._db.write(COMMITMENTS + '\n')
         for com in self._svr_commitments:
             self._db.write(com + '\n')
+        self._db.write(END_SECTION + '\n')
+
+    def post_start_of_vote_list(self) -> None:
+        """
+        Called when the PS begins to post a vote list (one of 2m total).
+        """
+        self._db.write(VOTE_LIST + '\n')

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Dict, List
 
 # Define SBB headings used to later parse the SBB during proof.
 BALLOT_RECEIPTS = 'ballot_receipts'
@@ -25,7 +25,7 @@ class SBB:
         """
         self._ballot_receipts.append(json.dumps({'bid': bid, 'receipt': receipt_str}, sort_keys=True))
 
-    def add_ballot_svr_commitment(self, com_u: bytes, com_v: bytes) -> None:
+    def add_ballot_svr_commitment(self, com_u: int, com_v: int) -> None:
         """
         Add a component of a ballot SVR to local receipt list, these are posted in bulk later.
 
@@ -33,7 +33,7 @@ class SBB:
         verification in the proof step.
         """
         self._svr_commitments.append(json.dumps(
-            {'com_u': com_u.hex(), 'com_v': com_v.hex()},
+            {'com_u': com_u, 'com_v': com_v},
             sort_keys=True,
         ))
 

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 
 # Define SBB headings used to later parse the SBB during proof.
 BALLOT_RECEIPTS = 'ballot_receipts'

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -51,8 +51,18 @@ class SBB:
             self._db.write(com + '\n')
         self._db.write(END_SECTION + '\n')
 
-    def post_start_of_vote_list(self) -> None:
+    def post_one_mixnet_output_list(self, com_t: List[Dict[int, Dict[str, int]]]) -> None:
         """
-        Called when the PS begins to post a vote list (one of 2m total).
+        Called once for each of the 2m lists posted after mixing.
+
+        For a 3 component SVR:
+            ComT = (ComSV(X), ComSV(Y), ComSV(Z))
+
+        There are N of these commitments, one per vote. Instead of x/y/z we use row
+        indices so that arbitrary sized mix-nets can be used.
         """
         self._db.write(VOTE_LIST + '\n')
+        self._db.write(json.dumps(com_t) + '\n')
+
+    def post_end_section(self) -> None:
+        self._db.write(END_SECTION + '\n')

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -1,11 +1,32 @@
 import json
 from typing import Dict, List
 
+FILENAME = 'sbb.txt'
+
 # Define SBB headings used to later parse the SBB during proof.
 BALLOT_RECEIPTS = 'ballot_receipts'
 COMMITMENTS = 'commitments'
 VOTE_LIST = 'vote_list'
 END_SECTION = 'end_section'
+
+
+class SBBContents:
+    """
+    Container type used for simplifying data access to the SBB.
+
+    After parsing the SBB, data is loaded into an instance of
+    SBBContents for consumers to access.
+    """
+    def __init__(self):
+        # Maps bids to receipt hashes.
+        self.ballot_receipts: Dict[int, str] = {}
+
+    def get_bid_receipt(self, bid: int) -> str:
+        """
+        Returns the ballot receipt for the provided bid.
+        """
+        return self.ballot_receipts[bid]
+
 
 class SBB:
     """
@@ -14,7 +35,7 @@ class SBB:
     def __init__(self):
         self._ballot_receipts: List[str] = []
         self._svr_commitments: List[str] = []
-        self._db: file = open('sbb.txt', 'w')
+        self._db: file = open(FILENAME, 'w')
 
     def close(self) -> None:
         self._db.close()
@@ -51,6 +72,10 @@ class SBB:
             self._db.write(com + '\n')
         self._db.write(END_SECTION + '\n')
 
+        # The sbb file is still open while elsewhere it is being read, so make sure
+        # output doesn't stay in the memory buffer.
+        self._db.flush()
+
     def post_one_mixnet_output_list(self, com_t: List[Dict[int, Dict[str, int]]]) -> None:
         """
         Called once for each of the 2m lists posted after mixing.
@@ -63,6 +88,48 @@ class SBB:
         """
         self._db.write(VOTE_LIST + '\n')
         self._db.write(json.dumps(com_t) + '\n')
+        self._db.flush()
 
     def post_end_section(self) -> None:
         self._db.write(END_SECTION + '\n')
+        self._db.flush()
+
+    def get_sbb_contents(self) -> SBBContents:
+        """
+        Parses the SBB and returns a container type for easier data access.
+
+        In practice this is something that each verifier would do either manually
+        (i.e. looking at the SBB for their bid) or programmatically (i.e. writing
+        a parser to verifier the SBB proof).
+
+        TODO - The SBB design and my method of parsing seem messy/confusing. Maybe
+        there is a way to simplify this.
+        """
+        sbb_contents = SBBContents()
+
+        with open(FILENAME, 'r') as f:
+            lines = f.read().splitlines()
+
+        i = 0
+        while i < len(lines) - 1:
+            heading = lines[i]
+            i += 1
+            line = lines[i]
+
+            if heading == BALLOT_RECEIPTS:
+                while line != END_SECTION:
+                    receipt = json.loads(line)
+                    sbb_contents.ballot_receipts[receipt['bid']] = receipt['receipt']
+                    i += 1
+                    line = lines[i]
+            elif heading == COMMITMENTS:
+                pass
+            elif heading == VOTE_LIST:
+                pass
+            else:
+                # TODO - uncomment below line once all parsing is complete.
+                # Or remove it if we go with a different parsing method.
+                # raise Exception('Unexpected SBB content')
+                pass
+
+        return sbb_contents

--- a/src/sv_vote.py
+++ b/src/sv_vote.py
@@ -1,11 +1,38 @@
 from typing import Optional
 
+from cryptography.fernet import Fernet
+
+
+class PlaintextCom:
+    """
+    PlaintextCom represents one plaintext commitment to a SVR tuple (u, v)
+    and the plaintext encryption keys used to make the commitment.
+    """
+    def __init__(self, k1: bytes, k2: bytes, u: bytes, v: bytes):
+        self.k1 = k1
+        self.k2 = k2
+        self.u = u
+        self.v = v
+
+
 class EncCom:
+    """
+    EncCom represents one encrypted commitment to a SVR tuple (u, v) and the
+    encrypted encryption keys used to make the commitment.
+    """
     def __init__(self):
-        self.k1 = None
-        self.k2 = None
-        self.u = None
-        self.v = None
+        self.k1: bytes = None
+        self.k2: bytes = None
+        self.u: bytes = None
+        self.v: bytes = None
+
+    def decode(self, decoder: Fernet) -> PlaintextCom:
+        k1 = decoder.decrypt(self.k1)
+        k2 = decoder.decrypt(self.k2)
+        u = decoder.decrypt(self.u)
+        v = decoder.decrypt(self.v)
+
+        return PlaintextCom(k1, k2, u, v)
 
 
 class SVVote:
@@ -13,6 +40,6 @@ class SVVote:
         self.bid = None                                    # Ballot ID
         self.com_u = None                                  # Commitment part 1
         self.com_v = None                                  # Commitment part 2
-        self.enc: Optional[EnvCom] = None                  # Encrypted K1, u, K2, v, for opening the commitment later
+        self.enc: EnvCom = None                            # Encrypted K1, u, K2, v, for opening the commitment later
         self.tablet_id = None                              # Tablet ID
         self.proof_server_row: Optional[int] = None        # Which proof server row this vote is going to

--- a/src/sv_vote.py
+++ b/src/sv_vote.py
@@ -3,10 +3,10 @@ from typing import Optional
 from cryptography.fernet import Fernet
 
 
-class PlaintextCom:
+class PlaintextSVR:
     """
-    PlaintextCom represents one plaintext commitment to a SVR tuple (u, v)
-    and the plaintext encryption keys used to make the commitment.
+    PlaintextSVR represents one SVR tuple (u, v) and the keys
+    encryption keys used to make a commitment to this SVR.
     """
     def __init__(self, k1: bytes, k2: bytes, u: bytes, v: bytes):
         self.k1 = k1
@@ -26,13 +26,13 @@ class EncCom:
         self.u: bytes = None
         self.v: bytes = None
 
-    def decode(self, decoder: Fernet) -> PlaintextCom:
+    def decode(self, decoder: Fernet) -> PlaintextSVR:
         k1 = decoder.decrypt(self.k1)
         k2 = decoder.decrypt(self.k2)
         u = decoder.decrypt(self.u)
         v = decoder.decrypt(self.v)
 
-        return PlaintextCom(k1, k2, u, v)
+        return PlaintextSVR(k1, k2, u, v)
 
 
 class SVVote:

--- a/src/tablet.py
+++ b/src/tablet.py
@@ -81,16 +81,10 @@ class Tablet:
             vote.tablet_id = self._id
             vote.proof_server_row = row
 
-            # Generate 2 random keys for the split-value representation
-            K1 = os.urandom(16)
-            K2 = os.urandom(16)
-
             # Create the commitment and set it on the vote. Together com_u and com_v make up ComSV in the paper
-            u, v = util.get_SV(val, self._M)
-            u_bytes = util.bigint_to_bytes(u)
-            v_bytes = util.bigint_to_bytes(v)
-            com_u = util.get_COM(K1, u_bytes)
-            com_v = util.get_COM(K2, v_bytes)
+            plaintext_svr = util.get_SVR(val, self._M)
+            com_u = util.get_COM(plaintext_svr.k1, plaintext_svr.u)
+            com_v = util.get_COM(plaintext_svr.k2, plaintext_svr.v)
             vote.com_u = com_u
             vote.com_v = com_v
 
@@ -102,10 +96,10 @@ class Tablet:
 
             # Encode the values (this is done as a concatenation in the paper, however it is easier to decode this way)
             enc = sv_vote.EncCom()
-            enc.k1 = self._encoder.encrypt(K1)
-            enc.k2 = self._encoder.encrypt(K2)
-            enc.u = self._encoder.encrypt(u_bytes)
-            enc.v = self._encoder.encrypt(v_bytes)
+            enc.k1 = self._encoder.encrypt(plaintext_svr.k1)
+            enc.k2 = self._encoder.encrypt(plaintext_svr.k2)
+            enc.u = self._encoder.encrypt(plaintext_svr.u)
+            enc.v = self._encoder.encrypt(plaintext_svr.v)
             vote.enc = enc
 
             # Send one vote per row to the proof servers

--- a/src/tablet.py
+++ b/src/tablet.py
@@ -60,7 +60,7 @@ class Tablet:
     #
     # Voting-related code
     #
-    def send_vote(self, vote_int: int) -> Tuple[bytes, str]:
+    def send_vote(self, vote_int: int) -> Tuple[int, str]:
         assert vote_int < self._M
 
         # TODO: use string votes and prime number generation?
@@ -107,4 +107,4 @@ class Tablet:
 
         self._sbb.add_ballot_receipt(bid_int, receipt_hash)
 
-        return bid, receipt_hash
+        return bid_int, receipt_hash

--- a/src/tablet.py
+++ b/src/tablet.py
@@ -35,7 +35,7 @@ class Tablet:
     def _create_secret_key(self):
         # Generate the secret key and encoder so that it doesn't need to be created for every vote.
         self._secret_key = Fernet.generate_key()
-        self._encoder = Fernet(self._secret_key)
+        self._encoder: Fernet = Fernet(self._secret_key)
 
     def _register_with_srv(self):
         # Get the public key from the server and load into a usable key object

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,5 @@
 import os
-from typing import Tuple
+from typing import List, Tuple
 
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.backends import default_backend
@@ -34,8 +34,11 @@ def get_SV(x: int, M: int) -> Tuple[int, int]:
     return u, v
 
 
-def get_SV_multiple(x, n, M):
-    split = []
+def get_SV_multiple(x: int, n: int, M: int) -> List[int]:
+    """
+    Return a random SVRs of the value `x` with `n` components.
+    """
+    split: List[int] = []
     for _ in range(n-1):
         rand_bytes = os.urandom(16)
         rand_int = bytes_to_bigint(rand_bytes)

--- a/src/util.py
+++ b/src/util.py
@@ -4,6 +4,8 @@ from typing import List, Tuple
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.backends import default_backend
 
+from src import sv_vote
+
 
 def bytes_to_bigint(byte_list: bytes):
     return int.from_bytes(byte_list, byteorder='little', signed=False)
@@ -19,6 +21,20 @@ def bigint_to_bytes(bigint: int):
             break
 
     return bigint.to_bytes(size, byteorder='little', signed=False)
+
+
+def get_SVR(x: int, M: int) -> sv_vote.PlaintextSVR:
+    """
+    Return a randomized SVR with keys necessary to commit to the SVR.
+    """
+    # Generate 2 random keys for the split-value representation
+    K1 = os.urandom(16)
+    K2 = os.urandom(16)
+
+    u, v = get_SV(x, M)
+    u_bytes = bigint_to_bytes(u)
+    v_bytes = bigint_to_bytes(v)
+    return sv_vote.PlaintextSVR(k1=K1, k2=K2, u=u_bytes, v=v_bytes)
 
 
 def get_SV(x: int, M: int) -> Tuple[int, int]:

--- a/src/util.py
+++ b/src/util.py
@@ -7,7 +7,7 @@ from cryptography.hazmat.backends import default_backend
 from src import sv_vote
 
 
-def bytes_to_bigint(byte_list: bytes):
+def bytes_to_bigint(byte_list: bytes) -> int:
     return int.from_bytes(byte_list, byteorder='little', signed=False)
 
 
@@ -75,7 +75,7 @@ def get_hash(byte_list: bytes) -> str:
     return digest.finalize().hex()
 
 
-def get_COM(K: bytes, u: bytes):
+def get_COM(K: bytes, u: bytes) -> int:
     """
     Commits the value u and is computationally hiding.
     To open the commitment, run this again and compare the values.
@@ -83,7 +83,7 @@ def get_COM(K: bytes, u: bytes):
     """
     h = hmac.HMAC(K, hashes.SHA256(), backend=default_backend())
     h.update(u)
-    return h.finalize()
+    return bytes_to_bigint(h.finalize())
 
 
 def val(u: int, v: int, M: int) -> int:

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -1,0 +1,20 @@
+from src import sbb
+
+class Verifier:
+    def __init__(self, sbb: sbb.SBB):
+        self._sbb = sbb
+
+    def verify_ballot_consistency(self) -> bool:
+        """
+        Returns True if the proof posted to SBB is verified to be consistent
+        with the cast votes posted to SBB by tablets during Step 3.
+
+        This method utilizes the partially decrypted un-shufffled but still
+        obfuscated SVRs posted to SBB by the PS and verifies equality using
+        the "Proving Equality of Arrays of Vote Values" procedure described
+        in Section II-F.
+        """
+        # TODO
+        # Parse SBB
+        # Use (t, -t) and prior commitments posted to verify
+        return True

--- a/src/voter.py
+++ b/src/voter.py
@@ -2,7 +2,7 @@ import random
 from typing import Optional
 
 from src.tablet import Tablet
-from src.sbb import SBB
+from src.sbb import SBBContents
 from src.sv_vote import SVVote
 
 
@@ -10,7 +10,7 @@ class Voter:
     def __init__(self, voter_id: int, M: int, vote: Optional[int] = None):
         self.voter_id: int = voter_id
         self.ballot_hash: str = ''
-        self.bid: Optional[bytes] = None
+        self.bid: Optional[int] = None
         self.M: int = M
         self.vote: Optional[int] = vote
 
@@ -22,5 +22,7 @@ class Voter:
 
         self.bid, self.ballot_hash = tablet.send_vote(self.vote)
 
-    def verify(self, sbb: SBB) -> bool:
-        return True
+    def verify(self, sbb_contents: SBBContents) -> bool:
+        if self.bid is None:
+            raise Exception('Voter does not have a valid bid, cannot verify vote')
+        return sbb_contents.get_bid_receipt(self.bid) == self.ballot_hash

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -2,6 +2,6 @@ from src import election
 
 
 def test_election():
-    elec = election.Election()
+    elec = election.Election(num_voters=3)
     elec.run()
     assert elec


### PR DESCRIPTION
I refer to election steps according to "Introduction and Overview" Section I.

This change:
- implements voter verification operation in step #4
- implements all of the mixing operations in step #5
- implements a simple approach for the random challenge step #6
- does some cleanup of types used for SVRs and commitments
- begins to formulate a method for structuring SBB so it can be parsed
  for steps #7 + #8
- adds a skeleton for `verifier.py` which is responsible for doing the
  actual step #7 proof verification

What is remaining:
1. Step #7 "Proving consistency with cast votes" - explained in Section
   IX. I know how to do the rearranging/backtracking mentioned. But
   unfortunately I've always been unclear on the details for how to do
   "Proving Equality of Arrays of Vote Values" (Section II-F). Of course
   the authors just write in Section IX "for brevity we omit the simple
   details of how [the proofserver] compute and post the pairs...". I
   could use help on figuring this bit out.
2. Step #8 "Posting and verification of the election outcome" - this
   should be easy, all the keys used for commitments are stored on the
   proofserver for every list/mixing-round/row, just need to open all
   the commitments and post them.