### PR TITLE
Add election outcome posting, tallying, and verification

### DIFF
--- a/src/election.py
+++ b/src/election.py
@@ -1,5 +1,5 @@
 import random
-from typing import Optional, Set
+from typing import List, Optional, Set
 
 from src import sbb
 from src import tablet
@@ -13,7 +13,7 @@ class Election:
         self,
         num_voters: int,
         M: int = 5,
-        twoM: int = 2,
+        twoM: int = 24,
         num_tablets: int = 3,
         num_proof_srv_rows: int = 3,
     ):
@@ -23,16 +23,48 @@ class Election:
         # level of assurance in the SBB posted proof. But increasing 2m also increases
         # memory usage and computation time.
         self.twoM = twoM
-        self.sbb = sbb.SBB()
+
+        self.sbb = sbb.SBB(num_voters=num_voters, twoM=self.twoM)
         self.proof_server = proof_server.ProofServer(
             M=self.M, twoM=self.twoM, rows=num_proof_srv_rows, sbb=self.sbb,
         )
-        self.verifier = verifier.Verifier(sbb=self.sbb)
+        self.verifier = verifier.Verifier(M=self.M, sbb=self.sbb, num_voters=num_voters)
         self.voters = [voter.Voter(voter_id=i, M=self.M) for i in range(num_voters)]
         self.tablets = [
             tablet.Tablet(srv=self.proof_server, M=self.M, sbb=self.sbb)
             for _ in range(num_tablets)
         ]
+
+    def _finish_election(self, outcome_lists: Set[int]) -> None:
+        """
+        Uses independent verifier to check tally using SBB and print results
+        if the SBB data passes verification.
+        """
+        # In theory this step can be taken by anyone because it only relies on
+        # data which is publically posted to the SBB.
+        print('Tallying and verifying election outcomes...\n')
+        final_tally = self.verifier.tally_and_verify_election_outcome(outcome_lists)
+
+        print('Final election tally:')
+        print("{:<10} {:<10}".format('Choice', 'Votes'))
+        winners: List[int] = []
+        most_votes = 0
+        for choice, votes in sorted(final_tally.items(), key=lambda x: x[0]):
+            if votes > most_votes:
+                winners = [choice]
+                most_votes = votes
+            elif votes == most_votes:
+                winners.append(choice)
+            print ("{:<10} {:<10}".format(choice, votes))
+
+        print()
+
+        if len(winners) == 1:
+            print(f'Election winner is choice: {winners[0]}')
+        else:
+            print(f'Election is a tie between choices: {winners}')
+
+        print('\nElection complete')
 
     def run(self):
         print('Running election...')
@@ -63,6 +95,7 @@ class Election:
         # Create a random challenge specifying which `m` lists to use for proving
         # consistency and (implicitly) which `m` votes to use for posting the
         # election outcome.
+        print('Creating random challenge...')
         all_two_m = set(range(self.twoM))
         proof_lists: Set[int] = set(random.sample(all_two_m, self.twoM // 2))
         outcome_lists: Set[int] = all_two_m - proof_lists
@@ -70,21 +103,23 @@ class Election:
 
         # Step 7
         # Tell PS which lists to un-shuffle, partially decrypt, and post to the SBB.
+        print('Publishing consistency proof...')
         self.proof_server.publish_vote_consistency_proof(proof_lists)
         # A unrelated verifier server should be able to read the SBB and verify the
         # proof that the partially decrypted votes are eqivalent to the SBB published
         # cast votes from Step 3.
+        print('Verifying consistency proof...')
         if not self.verifier.verify_ballot_consistency():
             raise Exception('Could not verifier consistency of SBB posted ballots')
 
         # Step 8
         # Tell PS which (still shuffled) lists to fully decrypt and post to the SBB.
+        print('Publishing election outcomes...')
         self.proof_server.publish_election_outcome(outcome_lists)
-
-        # Election complete, cleanup steps.
+        # Nothing left to publish to SBB.
         self.sbb.close()
-
-        print('Election complete')
+        # Compute tally and if verified, print results.
+        self._finish_election(outcome_lists)
 
     def _get_tablet(self) -> tablet.Tablet:
         """

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def parse_cmd_line(args):
         '-v', '--voters',
         action='store',
         dest='num_voters',
-        default=5,
+        default=10,
         type=int,
         help='number of voters to use, set randomly if not specified',
     )

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -1,13 +1,17 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, TextIO
+
+from src import sv_vote
+from src import util
 
 FILENAME = 'sbb.txt'
 
 # Define SBB headings used to later parse the SBB during proof.
 BALLOT_RECEIPTS = 'ballot_receipts'
-COMMITMENTS = 'commitments'
-VOTE_LIST = 'vote_list'
+ORIGINAL_ORDER_COMMITMENTS = 'original_order_commitments'
+MIXNET_VOTE_COMMITMENT_LIST = 'mixnet_vote_commitment_list'
 END_SECTION = 'end_section'
+ELECTION_OUTCOME = 'election_outcome'
 
 
 class SBBContents:
@@ -21,6 +25,18 @@ class SBBContents:
         # Maps bids to receipt hashes.
         self.ballot_receipts: Dict[int, str] = {}
 
+        # List of SVR commitment n-tuples.
+        # - 2m lists total
+        # - each list is n (number of votes) long
+        # - each entry in that list is a ComT value comprised of ComSV n-tuples
+        # See Section IX - "Posting of split-value representations of mix-net outputs"
+        self.vote_lists: List[List[List[util.ComSV]]] = []
+
+        # Maps list index to a list of SVR n-tuples.
+        # Where election_outcomes[i][j] is an n-tuple SVR representing the j'th vote
+        # (remember the position is shuffled) in the i'th posted list from the PS.
+        self.election_outcomes: Dict[int, List[List[sv_vote.PlaintextSVR]]] = {}
+
     def get_bid_receipt(self, bid: int) -> str:
         """
         Returns the ballot receipt for the provided bid.
@@ -32,10 +48,12 @@ class SBB:
     """
     Implements an interface for the Secure Bulletin Board (SBB).
     """
-    def __init__(self):
+    def __init__(self, num_voters: int, twoM: int):
+        self._num_voters: int = num_voters
+        self._twoM: int = twoM
         self._ballot_receipts: List[str] = []
         self._svr_commitments: List[str] = []
-        self._db: file = open(FILENAME, 'w')
+        self._db: TextIO = open(FILENAME, 'w')
 
     def close(self) -> None:
         self._db.close()
@@ -65,18 +83,25 @@ class SBB:
         self._db.write(BALLOT_RECEIPTS + '\n')
         for receipt in self._ballot_receipts:
             self._db.write(receipt + '\n')
-        self._db.write(END_SECTION + '\n')
+        self.post_end_section()
 
-        self._db.write(COMMITMENTS + '\n')
+        self._db.write(ORIGINAL_ORDER_COMMITMENTS + '\n')
         for com in self._svr_commitments:
             self._db.write(com + '\n')
-        self._db.write(END_SECTION + '\n')
+        self.post_end_section()
 
         # The sbb file is still open while elsewhere it is being read, so make sure
         # output doesn't stay in the memory buffer.
         self._db.flush()
 
-    def post_one_mixnet_output_list(self, com_t: List[Dict[int, Dict[str, int]]]) -> None:
+    def post_start_mixnet_output_list(self) -> None:
+        """
+        Called once by the PS prior to starting to post mixnet output lists,
+        of which there are 2m in total.
+        """
+        self._db.write(MIXNET_VOTE_COMMITMENT_LIST + '\n')
+
+    def post_one_mixnet_output_list(self, com_t: List[List[Dict[str, int]]]) -> None:
         """
         Called once for each of the 2m lists posted after mixing.
 
@@ -86,9 +111,20 @@ class SBB:
         There are N of these commitments, one per vote. Instead of x/y/z we use row
         indices so that arbitrary sized mix-nets can be used.
         """
-        self._db.write(VOTE_LIST + '\n')
         self._db.write(json.dumps(com_t) + '\n')
-        self._db.flush()
+
+    def post_start_election_outcome_proof(self) -> None:
+        """
+        Called once by the PS prior to starting to post election outcome results,
+        which are SVR commitment openings.
+        """
+        self._db.write(ELECTION_OUTCOME + '\n')
+
+    def post_one_election_outcome_proof(self, list_idx: int, svrs: List[List[Dict[str, int]]]) -> None:
+        """
+        Called once for each of the m lists which have all SVR commitments opened publicly.
+        """
+        self._db.write(json.dumps({'list_idx': list_idx, 'svrs': svrs}) + '\n')
 
     def post_end_section(self) -> None:
         self._db.write(END_SECTION + '\n')
@@ -101,9 +137,6 @@ class SBB:
         In practice this is something that each verifier would do either manually
         (i.e. looking at the SBB for their bid) or programmatically (i.e. writing
         a parser to verifier the SBB proof).
-
-        TODO - The SBB design and my method of parsing seem messy/confusing. Maybe
-        there is a way to simplify this.
         """
         sbb_contents = SBBContents()
 
@@ -122,13 +155,57 @@ class SBB:
                     sbb_contents.ballot_receipts[receipt['bid']] = receipt['receipt']
                     i += 1
                     line = lines[i]
-            elif heading == COMMITMENTS:
+                assert len(sbb_contents.ballot_receipts) == self._num_voters
+            elif heading == ORIGINAL_ORDER_COMMITMENTS:
+                # TODO
                 pass
-            elif heading == VOTE_LIST:
-                pass
+            elif heading == MIXNET_VOTE_COMMITMENT_LIST:
+                while line != END_SECTION:
+                    votes: List[List[util.ComSV]] = []
+
+                    vote_list = json.loads(line)
+                    for vl in vote_list:
+                        vote: List[util.ComSV] = []
+                        for component in vl:
+                            com_sv = util.ComSV(com_u=component['com_u'], com_v=component['com_v'])
+                            vote.append(com_sv)
+                        votes.append(vote)
+                    sbb_contents.vote_lists.append(votes)
+                    i += 1
+                    line = lines[i]
+
+                # Each vote commitment is a ComT, a n-tuple of ComSV values.
+                # There are num_votes total ComT values per PS "list" (1 of 2m).
+                assert len(sbb_contents.vote_lists) == self._twoM
+                assert all(
+                    len(sbb_contents.vote_lists[i]) == self._num_voters
+                    for i in range(self._twoM)
+                )
+            elif heading == ELECTION_OUTCOME:
+                while line != END_SECTION:
+                    svrs: List[List[sv_vote.PlaintextSVR]] = []
+
+                    outcome = json.loads(line)
+                    for svr in outcome['svrs']:
+                        opened_com_t: List[sv_vote.PlaintextSVR] = []
+                        for component in svr:
+                            p_svr = sv_vote.PlaintextSVR(
+                                k1=util.bigint_to_bytes(component['k1']),
+                                k2=util.bigint_to_bytes(component['k2']),
+                                u=util.bigint_to_bytes(component['u']),
+                                v=util.bigint_to_bytes(component['v']),
+                            )
+                            opened_com_t.append(p_svr)
+                        svrs.append(opened_com_t)
+                    sbb_contents.election_outcomes[outcome['list_idx']] = svrs
+                    i += 1
+                    line = lines[i]
+
+                assert len(sbb_contents.election_outcomes) == self._twoM // 2
+                for outcomes in sbb_contents.election_outcomes.values():
+                    assert len(outcomes) == self._num_voters
             else:
                 # TODO - uncomment below line once all parsing is complete.
-                # Or remove it if we go with a different parsing method.
                 # raise Exception('Unexpected SBB content')
                 pass
 

--- a/src/sv_vote.py
+++ b/src/sv_vote.py
@@ -1,18 +1,19 @@
+from dataclasses import dataclass
 from typing import Optional
 
 from cryptography.fernet import Fernet
 
 
+@dataclass
 class PlaintextSVR:
     """
     PlaintextSVR represents one SVR tuple (u, v) and the keys
     encryption keys used to make a commitment to this SVR.
     """
-    def __init__(self, k1: bytes, k2: bytes, u: bytes, v: bytes):
-        self.k1 = k1
-        self.k2 = k2
-        self.u = u
-        self.v = v
+    k1: bytes
+    k2: bytes
+    u: bytes
+    v: bytes
 
 
 class EncCom:

--- a/src/util.py
+++ b/src/util.py
@@ -1,10 +1,17 @@
 import os
+from dataclasses import dataclass
 from typing import List, Tuple
 
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.backends import default_backend
 
 from src import sv_vote
+
+
+@dataclass
+class ComSV:
+    com_u: int
+    com_v: int
 
 
 def bytes_to_bigint(byte_list: bytes) -> int:

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -1,8 +1,16 @@
+import typing
+from collections import Counter
+from typing import List, Set
+
 from src import sbb
+from src import util
+
 
 class Verifier:
-    def __init__(self, sbb: sbb.SBB):
+    def __init__(self, M: int, sbb: sbb.SBB, num_voters: int):
+        self._M = M
         self._sbb = sbb
+        self._num_voters = num_voters
 
     def verify_ballot_consistency(self) -> bool:
         """
@@ -18,3 +26,53 @@ class Verifier:
         # Parse SBB
         # Use (t, -t) and prior commitments posted to verify
         return True
+
+    def tally_and_verify_election_outcome(self, outcome_lists: Set[int]) -> typing.Counter[int]:
+        """
+        Reads the SBB, tallys votes using commitment openings posted by PS,
+        and compares commitment openings to previously posted ComT postings by PS.
+        If all tallys are permutations of the same values and the openings match
+        the previously posted ComT postings then returns the election tally,
+        otherwise raises an exception.
+        """
+        sbb_contents = self._sbb.get_sbb_contents()
+
+        # Keep tally counters for each of the m lists. All m tallies must
+        # be the same for the outcome to be verified.
+        raw_vote_tallies: List[typing.Counter[int]] = []
+        for idx in outcome_lists:
+            original_vote_list = sbb_contents.vote_lists[idx]
+            posted_outcome = sbb_contents.election_outcomes[idx]
+
+            assert len(original_vote_list) == len(posted_outcome) == self._num_voters
+
+            # First check that the opened commitments in the outcome lists match
+            # the original vote list commitments.
+            for og_com_t, outcome_com_t in zip(original_vote_list, posted_outcome):
+                for og_com_sv, outcome_com_sv in zip(og_com_t, outcome_com_t):
+                    if (util.get_COM(outcome_com_sv.k1, outcome_com_sv.u) != og_com_sv.com_u or
+                        util.get_COM(outcome_com_sv.k2, outcome_com_sv.v) != og_com_sv.com_v):
+                        raise Exception(
+                            'Election outcome commitment openings do not match original commitments'
+                        )
+
+            # Compute the raw vote value by iteratively applying each SVR component.
+            values: List[int] = [0 for _ in range(self._num_voters)]
+            for j, vote in enumerate(posted_outcome):
+                for svr in vote:
+                    values[j] = util.val(
+                        values[j],
+                        util.val(
+                            util.bytes_to_bigint(svr.u),
+                            util.bytes_to_bigint(svr.v),
+                            self._M,
+                        ),
+                        self._M,
+                    )
+            raw_vote_tallies.append(Counter(values))
+
+        # Ensure all tallies are equal.
+        if not all(tally == raw_vote_tallies[0] for tally in raw_vote_tallies):
+            raise Exception('Election outcome failed verification, not all tallies are equal')
+
+        return raw_vote_tallies[0]


### PR DESCRIPTION
This change implements step 8 from Section I, "Posting and verification
of election outcome".

After mixing and posting/verifying the proof (TODO), the PS now fully
decrypts the _other_ `m` lists by opening their commitments and posting
to the SBB. A separate function in `verifier.py` reads the SBB and
compares the opened commitments to the originally posted ones to make
sure they are the same, then it uses the opened commitments to SVRs to
compute all `m` election outcomes.

In addition to the SBB parsing changes needed for the above, I also
added some more stdout messages so you actually see the election
outcome. An example run is pasted below.

```
⫸ make
python3 -m src.main
Running election...
Voter ID: 0, vote is: 0
Voter ID: 1, vote is: 3
Voter ID: 2, vote is: 4
Voter ID: 3, vote is: 2
Voter ID: 4, vote is: 2
Voter ID: 5, vote is: 2
Voter ID: 6, vote is: 1
Voter ID: 7, vote is: 3
Voter ID: 8, vote is: 3
Voter ID: 9, vote is: 1
Voter ID: 0, verified posted ballot hash: 4759adc71e24cb1e60ee70aa4f139cf03697cb7af90108c5f5ed498e1fa2be9d
Voter ID: 1, verified posted ballot hash: b3aa128cda8eab89ba6e75b5c709087e803f791641066b3a3947abe2f3011a17
Voter ID: 2, verified posted ballot hash: a3f348915116625e63e0691e86c0ff2cb466986023d5776783fe76401f475684
Voter ID: 3, verified posted ballot hash: cad5b21208b6f153c88e620a01fc82977c6a195a5bf809168393f8b532946f58
Voter ID: 4, verified posted ballot hash: 333f754eb80ab2bb5440c8fc1ccd8b7f20746de5568705a3e05d19ff122691f0
Voter ID: 5, verified posted ballot hash: 203cc943a512e9d679025cd89490fdb3f50e990d365f52cc29090adee55618e9
Voter ID: 6, verified posted ballot hash: a04186ed043898a4c6362b7c5551f3b7b4fc4a350193a6d6d055db81583392d2
Voter ID: 7, verified posted ballot hash: 75e8cbbfe8ad8992b726a62d216aa79032a60e60a7517bf55db0eb12308ed445
Voter ID: 8, verified posted ballot hash: 26e8586f2e99146e8efd413e4704b767c743b39ce6ceaf633672324eb7e2a02f
Voter ID: 9, verified posted ballot hash: bad63852266f71e967c9bf3fccfb4faad6e12f6a4ff880217930c3f4238453c5
Mixing votes...
Creating random challenge...
Publishing consistency proof...
Verifying consistency proof...
Publishing election outcomes...
Tallying and verifying election outcomes...

Final election tally:
Choice     Votes
0          1
1          2
2          3
3          3
4          1

Election is a tie between choices: [2, 3]

Election complete
```

I was on a roll so figured I'd get this done. I'm going to hold off on
further changes until we meet on Thursday.