### PR TITLE
Consistency proof and verification

### DIFF
--- a/src/election.py
+++ b/src/election.py
@@ -8,11 +8,15 @@ from src import proof_server
 from src import verifier
 
 
+# Arbitrary large prime number
+DEFAULT_M = 235631359
+
+
 class Election:
     def __init__(
         self,
         num_voters: int,
-        M: int = 5,
+        M: int = DEFAULT_M,
         twoM: int = 24,
         num_tablets: int = 3,
         num_proof_srv_rows: int = 3,

--- a/src/election.py
+++ b/src/election.py
@@ -94,17 +94,20 @@ class Election:
         # Step 6
         # Create a random challenge specifying which `m` lists to use for proving
         # consistency and (implicitly) which `m` votes to use for posting the
-        # election outcome.
+        # election outcome. We also need to create a random binary list that selects
+        # between u and v for the consistency proof.
         print('Creating random challenge...')
         all_two_m = set(range(self.twoM))
         proof_lists: Set[int] = set(random.sample(all_two_m, self.twoM // 2))
         outcome_lists: Set[int] = all_two_m - proof_lists
         assert len(proof_lists) == len(outcome_lists) == self.twoM // 2
+        u_v_selection: List[int] = [random.randrange(2) for _ in self.voters]
+        assert len(u_v_selection) == len(self.voters)
 
         # Step 7
         # Tell PS which lists to un-shuffle, partially decrypt, and post to the SBB.
         print('Publishing consistency proof...')
-        self.proof_server.publish_vote_consistency_proof(proof_lists)
+        self.proof_server.publish_vote_consistency_proof(proof_lists, u_v_selection)
         # A unrelated verifier server should be able to read the SBB and verify the
         # proof that the partially decrypted votes are eqivalent to the SBB published
         # cast votes from Step 3.

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def parse_cmd_line(args):
         '-v', '--voters',
         action='store',
         dest='num_voters',
-        default=10,
+        default=9,
         type=int,
         help='number of voters to use, set randomly if not specified',
     )
@@ -32,4 +32,6 @@ if __name__ == '__main__':
     if parsed.interactive:
         print('Interactive mode not implemented yet')
     else:
-        election.Election(num_voters=parsed.num_voters).run()
+        # TODO: Remove!!
+        election.Election(num_voters=parsed.num_voters, twoM=4).run()
+        #election.Election(num_voters=parsed.num_voters).run()

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,4 @@ if __name__ == '__main__':
     if parsed.interactive:
         print('Interactive mode not implemented yet')
     else:
-        # TODO: Remove!!
-        election.Election(num_voters=parsed.num_voters, twoM=4).run()
-        #election.Election(num_voters=parsed.num_voters).run()
+        election.Election(num_voters=parsed.num_voters).run()

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def parse_cmd_line(args):
         '-v', '--voters',
         action='store',
         dest='num_voters',
-        default=9,
+        default=999,
         type=int,
         help='number of voters to use, set randomly if not specified',
     )

--- a/src/proof_server.py
+++ b/src/proof_server.py
@@ -275,10 +275,7 @@ class ProofServer:
                     util.bytes_to_bigint(plaintext_svr.v),
                     self._M,
                 )
-                
                 vote_components.append(component_value)
-                
-                # We technically do not need the keys here, but keeping them for simplicity.
                 initial_svr.append(plaintext_svr)
 
             assert len(vote_components) == self._num_votes

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -70,7 +70,7 @@ class SBB:
         self._num_voters: int = num_voters
         self._twoM: int = twoM
         self._ballot_receipts: List[str] = []
-        self._svr_commitments: List[List[Any]] = []
+        self._svr_commitments: List[List[Dict[str, int]]] = []
         self._db: TextIO = open(FILENAME, 'w')
         self.consistency_proof = {}
 
@@ -107,9 +107,6 @@ class SBB:
         self.post_end_section()
 
         self._db.write(ORIGINAL_ORDER_COMMITMENTS + '\n')
-        # TODO: fix this
-        #for com in self._svr_commitments:
-        #    self._db.write(com + '\n')
         self._db.write(json.dumps(self._svr_commitments) + '\n')
         self.post_end_section()
 
@@ -281,6 +278,4 @@ class SBB:
                 # raise Exception('Unexpected SBB content')
                 pass
 
-        # TODO: Clean this up
-        #sbb_contents.t_values = self.t_values
         return sbb_contents

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -72,9 +72,6 @@ class SBB:
         self._ballot_receipts: List[str] = []
         self._svr_commitments: List[List[Any]] = []
         self._db: TextIO = open(FILENAME, 'w')
-        # TODO: Remove!!
-        self.ordered_commitments = []
-        self.t_values = []
         self.consistency_proof = {}
 
     def close(self) -> None:
@@ -122,7 +119,7 @@ class SBB:
 
     def post_start_mixnet_output_list(self) -> None:
         """
-        Called once by tthe PS prior to starting o post mixnet output lists,
+        Called once by the PS prior to starting to post mixnet output lists,
         of which there are 2m in total.
         """
         self._db.write(MIXNET_VOTE_COMMITMENT_LIST + '\n')

--- a/src/sbb.py
+++ b/src/sbb.py
@@ -72,7 +72,7 @@ class SBB:
         self._ballot_receipts: List[str] = []
         self._svr_commitments: List[List[Dict[str, int]]] = []
         self._db: TextIO = open(FILENAME, 'w')
-        self.consistency_proof = {}
+        self.consistency_proof: Dict[int, List[List[Dict[str, int]]]] = {}
 
     def close(self) -> None:
         self._db.close()

--- a/src/sv_vote.py
+++ b/src/sv_vote.py
@@ -41,6 +41,6 @@ class SVVote:
         self.bid = None                                    # Ballot ID
         self.com_u = None                                  # Commitment part 1
         self.com_v = None                                  # Commitment part 2
-        self.enc: EnvCom = None                            # Encrypted K1, u, K2, v, for opening the commitment later
+        self.enc: EncCom = None                            # Encrypted K1, u, K2, v, for opening the commitment later
         self.tablet_id = None                              # Tablet ID
         self.proof_server_row: Optional[int] = None        # Which proof server row this vote is going to

--- a/src/tablet.py
+++ b/src/tablet.py
@@ -85,7 +85,7 @@ class Tablet:
             vote.com_v = util.get_COM(plaintext_svr.k2, plaintext_svr.v)
 
             # Each commitment for each component of the ballot must be posted to SBB.
-            self._sbb.add_ballot_svr_commitment(vote.com_u, vote.com_v)
+            self._sbb.add_ballot_svr_commitment(row, vote.com_u, vote.com_v)
 
             # Store the commitments in the receipt. Need to use int for it to be json serializable
             receipt[row] = {'u': vote.com_u, 'v': vote.com_v}

--- a/src/util.py
+++ b/src/util.py
@@ -95,3 +95,7 @@ def get_COM(K: bytes, u: bytes) -> int:
 
 def val(u: int, v: int, M: int) -> int:
     return (u + v) % M
+
+
+def t_val(u1: bytes, u2: bytes, M: int) -> int:
+    return (bytes_to_bigint(u2) - bytes_to_bigint(u1)) % M

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -22,6 +22,30 @@ class Verifier:
         the "Proving Equality of Arrays of Vote Values" procedure described
         in Section II-F.
         """
+        sbb_contents = self._sbb.get_sbb_contents()
+        
+        #t_values = sbb_contents.t_values
+        consistency_proof = sbb_contents.consistency_proof
+        
+        for list_idx, proof in consistency_proof.items():
+            for vote_idx in range(len(proof)):
+                # TODO: This is somewhat incorrect. We need to sum X, Y, and Z with (T) and return a T per vote, not per row? Maybe?
+                proved_sv = proof[vote_idx]
+                for row_idx, sv in enumerate(proved_sv):
+                    #t_val_uv = t_values[list_idx][row_idx][vote_idx]
+                    # TODO: where is the original vote SV?
+                    if sv.get('u', None) is not None:
+                        val = sv['u_init']
+                        original_commitment = sbb_contents.svr_commitments[row_idx][vote_idx]['com_u']
+                    else:
+                        val = sv['v_init']
+                        original_commitment = sbb_contents.svr_commitments[row_idx][vote_idx]['com_v']
+                    #compare_val = util.val(t_val, val, self._M)
+                    key = sv['k_init']
+                    commitement = util.get_COM(util.bigint_to_bytes(key), util.bigint_to_bytes(val))
+                    #commitement = util.get_COM(key, util.bigint_to_bytes(val))
+                    assert commitement == original_commitment
+            
         # TODO
         # Parse SBB
         # Use (t, -t) and prior commitments posted to verify

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -66,8 +66,8 @@ class Verifier:
                     tv_list.append(sbb_contents.t_values[list_idx][row_idx][vote_idx]['tv'])
                 
                 # Check that tu_list and tv_list lagrange to (t, -t)
-                tu_list = list(enumerate(tu_list, 1))
-                tv_list = list(enumerate(tv_list, 1))
+                tu_list = [enumerate(tu_list, 1)]
+                tv_list = [enumerate(tv_list, 1)]
                 rows = len(proved_sv)
                 tu0 = self._lagrange(tu_list, rows, rows-1, self._M)
                 tv0 = self._lagrange(tv_list, rows, rows-1, self._M)

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -50,9 +50,7 @@ class Verifier:
                     if com_fin != final_commitment:
                         raise Exception("Failed to open the final vote commitment")
             
-        # TODO
-        # Parse SBB
-        # Use (t, -t) and prior commitments posted to verify
+        # TODO: Use (t, -t) and prior commitments posted to verify consistency via lagrange
         return True
 
     def tally_and_verify_election_outcome(self, outcome_lists: Set[int]) -> typing.Counter[int]:

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -66,8 +66,8 @@ class Verifier:
                     tv_list.append(sbb_contents.t_values[list_idx][row_idx][vote_idx]['tv'])
                 
                 # Check that tu_list and tv_list lagrange to (t, -t)
-                tu_list = [enumerate(tu_list, 1)]
-                tv_list = [enumerate(tv_list, 1)]
+                tu_list = [(x,y) for x, y in enumerate(tu_list, 1)]
+                tv_list = [(x,y) for x, y in enumerate(tv_list, 1)]
                 rows = len(proved_sv)
                 tu0 = self._lagrange(tu_list, rows, rows-1, self._M)
                 tv0 = self._lagrange(tv_list, rows, rows-1, self._M)

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -66,8 +66,6 @@ class Verifier:
                     tv_list.append(sbb_contents.t_values[list_idx][row_idx][vote_idx]['tv'])
                 
                 # Check that tu_list and tv_list lagrange to (t, -t)
-                tu_list = [(x,y) for x, y in enumerate(tu_list, 1)]
-                tv_list = [(x,y) for x, y in enumerate(tv_list, 1)]
                 rows = len(proved_sv)
                 tu0 = self._lagrange(tu_list, rows, rows-1, self._M)
                 tv0 = self._lagrange(tv_list, rows, rows-1, self._M)
@@ -97,8 +95,11 @@ class Verifier:
         assert len(share_list) >= t
         if len(share_list) > t:
             share_list = share_list[:t]
-        x = [xy[0] for xy in share_list]
-        y = [xy[1] for xy in share_list]
+            
+        # Enumerate the shared list
+        share_list_enum = [(x,y) for x, y in enumerate(share_list, 1)]
+        x = [xy[0] for xy in share_list_enum]
+        y = [xy[1] for xy in share_list_enum]
         secret = 0
         for i in range(t):
             numerator = 1

--- a/src/voter.py
+++ b/src/voter.py
@@ -6,6 +6,9 @@ from src.sbb import SBBContents
 from src.sv_vote import SVVote
 
 
+DEFAULT_NUM_CANDIDATES = 2
+
+
 class Voter:
     def __init__(self, voter_id: int, M: int, vote: Optional[int] = None):
         self.voter_id: int = voter_id
@@ -16,7 +19,7 @@ class Voter:
 
     def do_vote(self, tablet: Tablet):
         if self.vote is None or self.vote >= self.M:
-            self.vote = random.choice(range(self.M))
+            self.vote = random.choice(range(DEFAULT_NUM_CANDIDATES))
 
         print(f'Voter ID: {self.voter_id}, vote is: {self.vote}')
 


### PR DESCRIPTION
This change implements consistency proving by checking the initial and final commitments of the random-challenge lists.
- Adds consistency proof to SBB
- Implements unmixing of votes
- SBB marshaling to "disk"
- Adds consistency verification in verifier

This change also implements t-values, however I'm not certain whether the implementation of it is correct (not sure if the unmixing is required for those). The lagrange consistency check is also not done and left as a TODO.